### PR TITLE
#159545736 Implement privacy defined restrictions for resource access

### DIFF
--- a/model/models.go
+++ b/model/models.go
@@ -157,7 +157,7 @@ type Resource struct {
 	Recommendations int64      `json:",omitempty"`
 	User            *User      `json:",omitempty"`
 	Comments        []*Comment `json:",omitempty"`
-	Tags            []Tag      `pg:",many2many:resource_tags" json:",omitempty"`
+	Tags            []*Tag     `pg:",many2many:resource_tags" json:",omitempty"`
 	BaseModel
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -35,6 +35,20 @@ var dummyData = map[string]interface{}{
 		"privacy": "public",
 		"tags":    []string{"Python", "Fortran", "Lisp"},
 	},
+	"privateResource": map[string]interface{}{
+		"title":   "A private resource",
+		"type":    "textual",
+		"link":    "https://localhost.textual/material/7.pdf",
+		"privacy": "private",
+		"tags":    []string{"Golang", "Rust"},
+	},
+	"followersResource": map[string]interface{}{
+		"title":   "A resource for followers only",
+		"type":    "audio",
+		"link":    "https://localhost.textual/material/8.pdf",
+		"privacy": "followers",
+		"tags":    []string{"JavaScript", "Scala"},
+	},
 	"collection1": map[string]interface{}{
 		"name": "first collection",
 	},
@@ -126,6 +140,7 @@ func addTestResource(t *testing.T, testData map[string]interface{}) Resource {
 				TagId:      tag.(*Tag).Id,
 				ResourceId: resource.Id,
 			})
+			resource.Tags = append(resource.Tags, tag.(*Tag))
 		}
 		if err := app.Db.Insert(resourceTags...); err != nil {
 			t.Fatal(err.Error())
@@ -162,4 +177,15 @@ func addTestCollection(t *testing.T, testData map[string]interface{}) Collection
 
 	return testCollection
 
+}
+
+func addTestConnection(t *testing.T, testData map[string]interface{}) {
+	testConnection := Connection{
+		InitiatorId: testData["initiatorId"].(int64),
+		RecipientId: testData["recipientId"].(int64),
+	}
+
+	if err := app.Db.Insert(&testConnection); err != nil {
+		t.Fatal(err.Error())
+	}
 }


### PR DESCRIPTION
#### What does this PR do?
Implements privacy defined restrictions for resource access

#### Description of completed tasks
- Check and apply resource privacy when a GET request is made to fetch a resource

#### How should this be manually tested?
- cd into project root directory and run `go test` command

#### Any background context?
Currently, an authenticated user can access any resource.

This PR aims to implement privacy by adding the following restrictions:
- When the privacy of a resource is **public**, **any authenticated user can access it**
- When the privacy of a resource is **private**, **only the owner of the resource can access it**
- When the privacy of a resource is **followers**, **it should be accessible to only the followers of the resource owner**

#### What are the relevant pivotal tracker stories?
#159545736